### PR TITLE
rewrite Blob when URL object is not present

### DIFF
--- a/Blob.js
+++ b/Blob.js
@@ -14,7 +14,7 @@
 
 /*! @source http://purl.eligrey.com/github/Blob.js/blob/master/Blob.js */
 
-if (typeof Blob !== "function")
+if (typeof Blob !== "function" || typeof URL === "undefined")
 var Blob = (function (view) {
 	"use strict";
 


### PR DESCRIPTION
Opera 12.10 supports Blob, but [doesn't support URL.createObjectURL](http://www.opera.com/docs/specs/presto2.12/apis/#file). As BlobBuilder.js defines its own URL.createObjectURL, it cannot work properly when the blob is not a "FakeBlob" (and URL is undefined).

This fixes https://github.com/eligrey/FileSaver.js/issues/10 for example.
