### PR TITLE
Fix blob for mozilla 10.0.4 esr

### DIFF
--- a/Blob.js
+++ b/Blob.js
@@ -15,7 +15,7 @@
 /*! @source http://purl.eligrey.com/github/Blob.js/blob/master/Blob.js */
 
 if (typeof Blob !== "function" || typeof URL === "undefined")
-if (typeof Blob === "function" && typeof webkitURL !== "undefined") var URL = webkitURL;
+if (typeof Blob === "function" && typeof webkitURL !== "undefined") URL = webkitURL;
 else var Blob = (function (view) {
 	"use strict";
 


### PR DESCRIPTION
On Mozilla 10.0.4 esr (and potentially other versions of Firefox that aren't recent) the syntax used in Blob.js causes a required global object to become undefined.

Despite the code not being executed (it is inside the if statement which does not return true in Firefox) just _loading_ this file in the FF version mentioned causes window.URL to become undefined - this is assumed to be present by the library hence the problem when you go to use it.

The fix for this is in this pull request. The workaround in the meantime is to put the following line of code on your page _before_ you load blob.js:

```
webkitURL = window.hasOwnProperty("webkitURL") ? webkitURL : URL;
```

Download the firefox version from here: https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/10.0.4esr/

Thanks
