### PR TITLE
fix detect bug in iOS

### DIFF
--- a/Blob.js
+++ b/Blob.js
@@ -14,8 +14,8 @@
 
 /*! @source http://purl.eligrey.com/github/Blob.js/blob/master/Blob.js */
 
-if (typeof Blob !== "function" || typeof URL === "undefined")
-if (typeof Blob === "function" && typeof webkitURL !== "undefined") self.URL = webkitURL;
+if (!(typeof Blob === "function" || typeof Blob === 'object') || typeof URL === "undefined")
+if ((typeof Blob === "function" || typeof Blob === 'object') && typeof webkitURL !== "undefined") self.URL = webkitURL;
 else var Blob = (function (view) {
 	"use strict";
 


### PR DESCRIPTION
``` javascript
typeof Blob
```

returns 'object' instead of 'function' on iOS (tested on iOS 6.1)
thus will cause native Blob overwritten on iOS.
