### PR TITLE
Fixed feature detection in Webkit and global decl.

### DIFF
--- a/Blob.js
+++ b/Blob.js
@@ -15,10 +15,10 @@
 /*! @source http://purl.eligrey.com/github/Blob.js/blob/master/Blob.js */
 
 if (!(typeof Blob === "function" || typeof Blob === "object") || typeof URL === "undefined")
-if ((typeof Blob === "function" || typeof Blob === "object") && typeof webkitURL !== "undefined") self.URL = webkitURL;
-else var Blob = (function (view) {
+window.Blob = (function (view) {
 	"use strict";
 
+	view.URL = view.URL || view.webkitURL;
 	var BlobBuilder = view.BlobBuilder || view.WebKitBlobBuilder || view.MozBlobBuilder || view.MSBlobBuilder || (function(view) {
 		var
 			  get_class = function(object) {


### PR DESCRIPTION
Fixed #22 and #24 and changed Blob declaration to method of window
object (=global), which makes it work in Meteor environment.

Tested on:

OS X:
- Opera 11.62
- Opera 21.0
- Safari 7.0.3
- Chrome 35.0
- Firefox 3.6
- Firefox 10.0.4
- Firefox 29.0.1

iOS 7:
- Safari
- Opera mini 7.0.5
- Opera Coast 3.0.1
- Chrome 30.04

Windows 7:
- Safari 5.1.7
- IE 9
