### PR TITLE
IE8: Add support for instanceof

### DIFF
--- a/Blob.js
+++ b/Blob.js
@@ -158,7 +158,10 @@
 			if (!arguments.length) {
 				type = null;
 			}
-			return new FakeBlob(this.data.join(""), type, "raw");
+			var result = new FakeBlob(this.data.join(""), type, "raw");
+			if(!result.__proto__)
+				result.__proto__ = FB_proto;
+			return result;
 		};
 		FBB_proto.toString = function() {
 			return "[object BlobBuilder]";


### PR DESCRIPTION
<p>When I use IE8 (I know it is old), neither objects have <strong>__proto__</strong> property nor <strong>Object</strong> class has <strong>getPrototypeOf</strong> method. Therefore the following instruction will set <strong>prototype</strong> to <strong>undefined</strong></p>

<pre><code>
view.Blob.prototype = getPrototypeOf(new view.Blob()); 
</code></pre>

<p>Setting <strong>__proto__</strong> property on <strong>FakeBlob</strong> if not present does the job</p>
