### PR TITLE
Compatibility overhaul

### DIFF
--- a/Blob.js
+++ b/Blob.js
@@ -8,8 +8,7 @@
  *   See https://github.com/eligrey/Blob.js/blob/master/LICENSE.md
  */
 
-;(function(){
-
+;(function () {
   var global = typeof window === 'object'
       ? window : typeof self === 'object'
       ? self : this
@@ -17,9 +16,9 @@
   var BlobBuilder = global.BlobBuilder
     || global.WebKitBlobBuilder
     || global.MSBlobBuilder
-    || global.MozBlobBuilder;
+    || global.MozBlobBuilder
 
-  global.URL = global.URL || global.webkitURL || function(href, a) {
+  global.URL = global.URL || global.webkitURL || function (href, a) {
   	a = document.createElement('a')
   	a.href = href
   	return a
@@ -34,7 +33,7 @@
   var arrayBufferSupported = !!global.ArrayBuffer
   var blobBuilderSupported = BlobBuilder
     && BlobBuilder.prototype.append
-    && BlobBuilder.prototype.getBlob;
+    && BlobBuilder.prototype.getBlob
 
   try {
     // Check if Blob constructor is supported
@@ -42,151 +41,149 @@
 
     // Check if Blob constructor supports ArrayBufferViews
     // Fails in Safari 6, so we need to map to ArrayBuffers there.
-    blobSupportsArrayBufferView = new Blob([new Uint8Array([1,2])]).size === 2
-  } catch(e) {}
+    blobSupportsArrayBufferView = new Blob([new Uint8Array([1, 2])]).size === 2
+  } catch (e) {}
 
   /**
    * Helper function that maps ArrayBufferViews to ArrayBuffers
    * Used by BlobBuilder constructor and old browsers that didn't
    * support it in the Blob constructor.
    */
-  function mapArrayBufferViews(ary) {
-    return ary.map(function(chunk) {
+  function mapArrayBufferViews (ary) {
+    return ary.map(function (chunk) {
       if (chunk.buffer instanceof ArrayBuffer) {
-        var buf = chunk.buffer;
+        var buf = chunk.buffer
 
         // if this is a subarray, make a copy so we only
         // include the subarray region from the underlying buffer
         if (chunk.byteLength !== buf.byteLength) {
-          var copy = new Uint8Array(chunk.byteLength);
-          copy.set(new Uint8Array(buf, chunk.byteOffset, chunk.byteLength));
-          buf = copy.buffer;
+          var copy = new Uint8Array(chunk.byteLength)
+          copy.set(new Uint8Array(buf, chunk.byteOffset, chunk.byteLength))
+          buf = copy.buffer
         }
 
-        return buf;
+        return buf
       }
 
-      return chunk;
-    });
+      return chunk
+    })
   }
 
-  function BlobBuilderConstructor(ary, options) {
-    options = options || {};
+  function BlobBuilderConstructor (ary, options) {
+    options = options || {}
 
-    var bb = new BlobBuilder();
-    mapArrayBufferViews(ary).forEach(function(part) {
-      bb.append(part);
-    });
+    var bb = new BlobBuilder()
+    mapArrayBufferViews(ary).forEach(function (part) {
+      bb.append(part)
+    })
 
-    return options.type ? bb.getBlob(options.type) : bb.getBlob();
-  };
+    return options.type ? bb.getBlob(options.type) : bb.getBlob()
+  }
 
-  function BlobConstructor(ary, options) {
-    return new origBlob(mapArrayBufferViews(ary), options || {});
-  };
+  function BlobConstructor (ary, options) {
+    return new origBlob(mapArrayBufferViews(ary), options || {})
+  }
 
   if (global.Blob) {
-    BlobBuilderConstructor.prototype = Blob.prototype;
-    BlobConstructor.prototype = Blob.prototype;
+    BlobBuilderConstructor.prototype = Blob.prototype
+    BlobConstructor.prototype = Blob.prototype
   }
 
-  function FakeBlobBuilder() {
-    function toUTF8Array(str) {
-      var utf8 = [];
-      for (var i=0; i < str.length; i++) {
-        var charcode = str.charCodeAt(i);
-        if (charcode < 0x80) utf8.push(charcode);
+  function FakeBlobBuilder () {
+    function toUTF8Array (str) {
+      var utf8 = []
+      for (var i = 0; i < str.length; i++) {
+        var charcode = str.charCodeAt(i)
+        if (charcode < 0x80) utf8.push(charcode)
         else if (charcode < 0x800) {
-          utf8.push(0xc0 | (charcode >> 6), 
-          0x80 | (charcode & 0x3f));
-        }
-        else if (charcode < 0xd800 || charcode >= 0xe000) {
-          utf8.push(0xe0 | (charcode >> 12), 
-          0x80 | ((charcode>>6) & 0x3f), 
-          0x80 | (charcode & 0x3f));
+          utf8.push(0xc0 | (charcode >> 6),
+          0x80 | (charcode & 0x3f))
+        } else if (charcode < 0xd800 || charcode >= 0xe000) {
+          utf8.push(0xe0 | (charcode >> 12),
+          0x80 | ((charcode >> 6) & 0x3f),
+          0x80 | (charcode & 0x3f))
         }
         // surrogate pair
         else {
-          i++;
+          i++
           // UTF-16 encodes 0x10000-0x10FFFF by
           // subtracting 0x10000 and splitting the
           // 20 bits of 0x0-0xFFFFF into two halves
-          charcode = 0x10000 + (((charcode & 0x3ff)<<10)
-          | (str.charCodeAt(i) & 0x3ff));
-          utf8.push(0xf0 | (charcode >>18), 
-          0x80 | ((charcode>>12) & 0x3f), 
-          0x80 | ((charcode>>6) & 0x3f), 
-          0x80 | (charcode & 0x3f));
+          charcode = 0x10000 + (((charcode & 0x3ff) << 10)
+          | (str.charCodeAt(i) & 0x3ff))
+          utf8.push(0xf0 | (charcode >> 18),
+          0x80 | ((charcode >> 12) & 0x3f),
+          0x80 | ((charcode >> 6) & 0x3f),
+          0x80 | (charcode & 0x3f))
         }
       }
-      return utf8;
+      return utf8
     }
-    function fromUtf8Array(array) {
-      var out, i, len, c;
-      var char2, char3;
-      
-      out = "";
-      len = array.length;
-      i = 0;
+    function fromUtf8Array (array) {
+      var out, i, len, c
+      var char2, char3
+
+      out = ''
+      len = array.length
+      i = 0
       while (i < len) {
-        c = array[i++];
-        switch (c >> 4)
-        { 
+        c = array[i++]
+        switch (c >> 4) {
           case 0: case 1: case 2: case 3: case 4: case 5: case 6: case 7:
           // 0xxxxxxx
-          out += String.fromCharCode(c);
-          break;
+            out += String.fromCharCode(c)
+            break
           case 12: case 13:
           // 110x xxxx   10xx xxxx
-          char2 = array[i++];
-          out += String.fromCharCode(((c & 0x1F) << 6) | (char2 & 0x3F));
-          break;
+            char2 = array[i++]
+            out += String.fromCharCode(((c & 0x1F) << 6) | (char2 & 0x3F))
+            break
           case 14:
           // 1110 xxxx  10xx xxxx  10xx xxxx
-          char2 = array[i++];
-          char3 = array[i++];
-          out += String.fromCharCode(((c & 0x0F) << 12) |
+            char2 = array[i++]
+            char3 = array[i++]
+            out += String.fromCharCode(((c & 0x0F) << 12) |
           ((char2 & 0x3F) << 6) |
-          ((char3 & 0x3F) << 0));
-          break;
+          ((char3 & 0x3F) << 0))
+            break
         }
-      }    
-      return out;
+      }
+      return out
     }
-    function isDataView(obj) {
+    function isDataView (obj) {
       return obj && DataView.prototype.isPrototypeOf(obj)
     }
-    function bufferClone(buf) {
+    function bufferClone (buf) {
       var view = new Array(buf.byteLength)
       var array = new Uint8Array(buf)
       var i = view.length
-      while(i--) {
+      while (i--) {
         view[i] = array[i]
       }
       return view
     }
-    function encodeByteArray(input) {
-      var byteToCharMap = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+    function encodeByteArray (input) {
+      var byteToCharMap = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='
 
-      var output = [];
+      var output = []
 
       for (var i = 0; i < input.length; i += 3) {
-        var byte1 = input[i];
-        var haveByte2 = i + 1 < input.length;
-        var byte2 = haveByte2 ? input[i + 1] : 0;
-        var haveByte3 = i + 2 < input.length;
-        var byte3 = haveByte3 ? input[i + 2] : 0;
+        var byte1 = input[i]
+        var haveByte2 = i + 1 < input.length
+        var byte2 = haveByte2 ? input[i + 1] : 0
+        var haveByte3 = i + 2 < input.length
+        var byte3 = haveByte3 ? input[i + 2] : 0
 
-        var outByte1 = byte1 >> 2;
-        var outByte2 = ((byte1 & 0x03) << 4) | (byte2 >> 4);
-        var outByte3 = ((byte2 & 0x0F) << 2) | (byte3 >> 6);
-        var outByte4 = byte3 & 0x3F;
+        var outByte1 = byte1 >> 2
+        var outByte2 = ((byte1 & 0x03) << 4) | (byte2 >> 4)
+        var outByte3 = ((byte2 & 0x0F) << 2) | (byte3 >> 6)
+        var outByte4 = byte3 & 0x3F
 
         if (!haveByte3) {
-          outByte4 = 64;
+          outByte4 = 64
 
           if (!haveByte2) {
-            outByte3 = 64;
+            outByte3 = 64
           }
         }
 
@@ -199,11 +196,11 @@
     }
 
     var create = Object.create || function (a) {
-      function c() {}
-      c.prototype = a;
-      return new c
+      function c () {}
+      c.prototype = a
+      return new c()
     }
-    
+
     if (arrayBufferSupported) {
       var viewClasses = [
         '[object Int8Array]',
@@ -217,17 +214,15 @@
         '[object Float64Array]'
       ]
 
-      var isArrayBufferView = ArrayBuffer.isView || function(obj) {
+      var isArrayBufferView = ArrayBuffer.isView || function (obj) {
         return obj && viewClasses.indexOf(Object.prototype.toString.call(obj)) > -1
       }
     }
 
-    
-    
     /********************************************************/
     /*                   Blob constructor                   */
     /********************************************************/
-    function Blob(chunks, opts) {
+    function Blob (chunks, opts) {
       chunks = chunks || []
       for (var i = 0, len = chunks.length; i < len; i++) {
         var chunk = chunks[i]
@@ -249,54 +244,52 @@
       this.type = opts ? opts.type || '' : ''
     }
 
-    Blob.prototype.slice = function(start, end, type) {
+    Blob.prototype.slice = function (start, end, type) {
       var slice = this._buffer.slice(start || 0, end || this._buffer.length)
       return new Blob([slice], {type: type})
     }
 
-    Blob.prototype.toString = function() {
+    Blob.prototype.toString = function () {
       return '[object Blob]'
     }
-
-    
 
     /********************************************************/
     /*                   File constructor                   */
     /********************************************************/
-    function File(chunks, name, opts) {
+    function File (chunks, name, opts) {
       opts = opts || {}
       var a = Blob.call(this, chunks, opts) || this
       a.name = name
-      a.lastModifiedDate = opts.lastModified ? new Date(opts.lastModified) : new Date
+      a.lastModifiedDate = opts.lastModified ? new Date(opts.lastModified) : new Date()
       a.lastModified = +a.lastModifiedDate
-      
+
       return a
     }
 
-    File.prototype = create(Blob.prototype);
-    File.prototype.constructor = File;
+    File.prototype = create(Blob.prototype)
+    File.prototype.constructor = File
 
-    if (Object.setPrototypeOf) 
-      Object.setPrototypeOf(File, Blob);
-    else {
-      try {File.__proto__ = Blob} catch (e) {}
+    if (Object.setPrototypeOf) {
+      Object.setPrototypeOf(File, Blob)
+    } else {
+      try { File.__proto__ = Blob } catch (e) {}
     }
 
-    File.prototype.toString = function() {
+    File.prototype.toString = function () {
       return '[object File]'
     }
 
-    
     /********************************************************/
     /*                FileReader constructor                */
     /********************************************************/
-    function FileReader() {
-    	if (!(this instanceof FileReader))
-    		throw new TypeError("Failed to construct 'FileReader': Please use the 'new' operator, this DOM object constructor cannot be called as a function.")
+    function FileReader () {
+    	if (!(this instanceof FileReader))    		{
+      throw new TypeError("Failed to construct 'FileReader': Please use the 'new' operator, this DOM object constructor cannot be called as a function.")
+    }
 
     	var delegate = document.createDocumentFragment()
     	this.addEventListener = delegate.addEventListener
-    	this.dispatchEvent = function(evt) {
+    	this.dispatchEvent = function (evt) {
     		var local = this['on' + evt.type]
     		if (typeof local === 'function') local(evt)
     		delegate.dispatchEvent(evt)
@@ -304,13 +297,14 @@
     	this.removeEventListener = delegate.removeEventListener
     }
 
-    function _read(fr, blob, kind) {
-    	if (!(blob instanceof Blob))
-    		throw new TypeError("Failed to execute '" + kind + "' on 'FileReader': parameter 1 is not of type 'Blob'.")
-    	
+    function _read (fr, blob, kind) {
+    	if (!(blob instanceof Blob))    		{
+      throw new TypeError("Failed to execute '" + kind + "' on 'FileReader': parameter 1 is not of type 'Blob'.")
+    }
+
     	fr.result = ''
 
-    	setTimeout(function(){
+    	setTimeout(function () {
     		this.readyState = FileReader.LOADING
     		fr.dispatchEvent(new Event('load'))
     		fr.dispatchEvent(new Event('loadend'))
@@ -328,34 +322,33 @@
     FileReader.prototype.onloadstart = null
     FileReader.prototype.onprogress = null
 
-    FileReader.prototype.readAsDataURL = function(blob) {
+    FileReader.prototype.readAsDataURL = function (blob) {
     	_read(this, blob, 'readAsDataURL')
     	this.result = 'data:' + blob.type + ';base64,' + encodeByteArray(blob._buffer)
     }
 
-    FileReader.prototype.readAsText = function(blob) {
+    FileReader.prototype.readAsText = function (blob) {
     	_read(this, blob, 'readAsText')
     	this.result = fromUtf8Array(blob._buffer)
     }
 
-    FileReader.prototype.readAsArrayBuffer = function(blob) {
+    FileReader.prototype.readAsArrayBuffer = function (blob) {
     	_read(this, blob, 'readAsText')
     	this.result = blob._buffer.slice()
     }
 
-    FileReader.prototype.abort = function() {}
+    FileReader.prototype.abort = function () {}
 
-    
     /********************************************************/
     /*                         URL                          */
     /********************************************************/
-    URL.createObjectURL = function(blob) {
-      return blob instanceof Blob 
+    URL.createObjectURL = function (blob) {
+      return blob instanceof Blob
         ? 'data:' + blob.type + ';base64,' + encodeByteArray(blob._buffer)
         : createObjectURL.call(URL, blob)
     }
-    
-    URL.revokeObjectURL = function(url) {
+
+    URL.revokeObjectURL = function (url) {
       revokeObjectURL && revokeObjectURL.call(URL, url)
     }
 
@@ -364,7 +357,7 @@
     /********************************************************/
     var _send = global.XMLHttpRequest && global.XMLHttpRequest.prototype.send
     if (_send) {
-      XMLHttpRequest.prototype.send = function(data) {
+      XMLHttpRequest.prototype.send = function (data) {
         if (data instanceof Blob) {
           this.setRequestHeader('Content-Type', data.type)
           _send.call(this, fromUtf8Array(data._buffer))
@@ -373,7 +366,7 @@
         }
       }
     }
-    
+
     global.FileReader = FileReader
     global.File = File
     global.Blob = Blob
@@ -385,18 +378,18 @@
     FileReader.prototype[strTag] = 'FileReader'
   }
 
-  function fixFileAndXHR() {
+  function fixFileAndXHR () {
     var isIE = !!global.ActiveXObject || (
-      '-ms-scroll-limit' in document.documentElement.style && 
+      '-ms-scroll-limit' in document.documentElement.style &&
       '-ms-ime-align' in document.documentElement.style
     )
 
-    // Monkey patched 
+    // Monkey patched
     // IE don't set Content-Type header on XHR whose body is a typed Blob
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/6047383
     var _send = global.XMLHttpRequest && global.XMLHttpRequest.prototype.send
     if (isIE && _send) {
-      XMLHttpRequest.prototype.send = function(data) {
+      XMLHttpRequest.prototype.send = function (data) {
         if (data instanceof Blob) {
           this.setRequestHeader('Content-Type', data.type)
           _send.call(this, data)
@@ -408,34 +401,35 @@
 
     try {
       new File([], '')
-    } catch(e) {
+    } catch (e) {
       try {
-        var klass = new Function('class File extends Blob {' + 
+        var klass = new Function('class File extends Blob {' +
           'constructor(chunks, name, opts) {' +
             'opts = opts || {};' +
             'super(chunks, opts || {});' +
             'this.name = name;' +
-            'this.lastModifiedDate = opts.lastModified ? new Date(opts.lastModified) : new Date;' +
+            'this.lastModifiedDate = opts.lastModified ? new Date(opts.lastModified) : new Date();' +
             'this.lastModified = +this.lastModifiedDate;' +
           '}};' +
           'return new File([], ""), File'
         )()
         global.File = klass
-      } catch(e) {
-        var klass = function(b, d, c) {
+      } catch (e) {
+        var klass = function (b, d, c) {
           var blob = new Blob(b, c)
-          var t = c && void 0 !== c.lastModified ? new Date(c.lastModified) : new Date
-          
+          var t = c && void 0 !== c.lastModified ? new Date(c.lastModified) : new Date()
+
           blob.name = d
           blob.lastModifiedDate = t
           blob.lastModified = +t
-          blob.toString = function() {
+          blob.toString = function () {
             return '[object File]'
           }
-          
-          if (strTag)
+
+          if (strTag) {
             blob[strTag] = 'File'
-          
+          }
+
           return blob
         }
         global.File = klass
@@ -448,9 +442,8 @@
     global.Blob = blobSupportsArrayBufferView ? global.Blob : BlobConstructor
   } else if (blobBuilderSupported) {
     fixFileAndXHR()
-    global.Blob = BlobBuilderConstructor;
+    global.Blob = BlobBuilderConstructor
   } else {
     FakeBlobBuilder()
   }
-
-})();
+})()

--- a/Blob.js
+++ b/Blob.js
@@ -358,7 +358,14 @@
         ? concatTypedarrays(chunks)
         : [].concat.apply([], chunks)
       this.size = this._buffer.length
-      this.type = opts ? opts.type || '' : ''
+
+      this.type = opts.type || ''
+      if (/[^\u0020-\u007E]/.test(this.type)) {
+        this.type = ''
+      } else {
+        this.type = this.type.toLowerCase()
+      }
+
     }
 
     Blob.prototype.slice = function (start, end, type) {

--- a/Blob.js
+++ b/Blob.js
@@ -319,6 +319,21 @@
       }
     }
 
+    function concatTypedarrays (chunks) {
+      var size = 0
+      var i = chunks.length
+      while (i--) { size += chunks[i].length }
+      var b = new Uint8Array(size)
+      var offset = 0
+      for (i = 0, l = chunks.length; i < l; i++) {
+        var chunk = chunks[i]
+        b.set(chunk, offset)
+        offset += chunk.byteLength || chunk.length
+      }
+
+      return b
+    }
+
     /********************************************************/
     /*                   Blob constructor                   */
     /********************************************************/
@@ -339,7 +354,9 @@
         }
       }
 
-      this._buffer = [].concat.apply([], chunks)
+      this._buffer = global.Uint8Array
+        ? concatTypedarrays(chunks)
+        : [].concat.apply([], chunks)
       this.size = this._buffer.length
       this.type = opts ? opts.type || '' : ''
     }

--- a/Blob.js
+++ b/Blob.js
@@ -465,8 +465,9 @@
     }
 
     FileReader.prototype.readAsArrayBuffer = function (blob) {
-    	_read(this, blob, 'readAsText')
-    	this.result = blob._buffer.slice()
+      _read(this, blob, 'readAsText')
+       // return ArrayBuffer when possible
+      this.result = (blob._buffer.buffer || blob._buffer).slice()
     }
 
     FileReader.prototype.abort = function () {}

--- a/Blob.js
+++ b/Blob.js
@@ -366,7 +366,14 @@
       } else {
         this.type = this.type.toLowerCase()
       }
+    }
 
+    Blob.prototype.arrayBuffer = function () {
+      return Promise.resolve(this._buffer)
+    }
+
+    Blob.prototype.text = function () {
+      return Promise.resolve(textDecode(this._buffer))
     }
 
     Blob.prototype.slice = function (start, end, type) {

--- a/Blob.js
+++ b/Blob.js
@@ -339,6 +339,7 @@
     /********************************************************/
     function Blob (chunks, opts) {
       chunks = chunks || []
+      opts = opts == null ? {} : opts
       for (var i = 0, len = chunks.length; i < len; i++) {
         var chunk = chunks[i]
         if (chunk instanceof Blob) {
@@ -383,7 +384,7 @@
     function File (chunks, name, opts) {
       opts = opts || {}
       var a = Blob.call(this, chunks, opts) || this
-      a.name = name
+      a.name = name.replace(/\//g, ':')
       a.lastModifiedDate = opts.lastModified ? new Date(opts.lastModified) : new Date()
       a.lastModified = +a.lastModifiedDate
 
@@ -525,7 +526,7 @@
           'constructor(chunks, name, opts) {' +
             'opts = opts || {};' +
             'super(chunks, opts || {});' +
-            'this.name = name;' +
+            'this.name = name.replace(/\//g, ":");' +
             'this.lastModifiedDate = opts.lastModified ? new Date(opts.lastModified) : new Date();' +
             'this.lastModified = +this.lastModifiedDate;' +
           '}};' +
@@ -537,7 +538,7 @@
           var blob = new Blob(b, c)
           var t = c && void 0 !== c.lastModified ? new Date(c.lastModified) : new Date()
 
-          blob.name = d
+          blob.name = d.replace(/\//g, ':')
           blob.lastModifiedDate = t
           blob.lastModified = +t
           blob.toString = function () {

--- a/Blob.js
+++ b/Blob.js
@@ -472,12 +472,6 @@
     global.Blob = Blob
   }
 
-  if (strTag) {
-    File.prototype[strTag] = 'File'
-    Blob.prototype[strTag] = 'Blob'
-    FileReader.prototype[strTag] = 'FileReader'
-  }
-
   function fixFileAndXHR () {
     var isIE = !!global.ActiveXObject || (
       '-ms-scroll-limit' in document.documentElement.style &&
@@ -545,6 +539,12 @@
     global.Blob = BlobBuilderConstructor
   } else {
     FakeBlobBuilder()
+  }
+
+  if (strTag) {
+    File.prototype[strTag] = 'File'
+    Blob.prototype[strTag] = 'Blob'
+    FileReader.prototype[strTag] = 'FileReader'
   }
 
   var blob = global.Blob.prototype

--- a/Blob.js
+++ b/Blob.js
@@ -239,12 +239,12 @@
   }
 
   // string -> buffer
-  var textEncode = typeof TextEncoder === 'object'
+  var textEncode = typeof TextEncoder === 'function'
     ? TextEncoder.prototype.encode.bind(new TextEncoder())
     : stringEncode
 
   // buffer -> string
-  var textDecode = typeof TextDecoder === 'object'
+  var textDecode = typeof TextDecoder === 'function'
     ? TextDecoder.prototype.decode.bind(new TextDecoder())
     : stringDecode
 

--- a/Blob.js
+++ b/Blob.js
@@ -1,6 +1,6 @@
 /* Blob.js
  * A Blob, File, FileReader & URL implementation.
- * 2018-08-09
+ * 2019-04-19
  *
  * By Eli Grey, http://eligrey.com
  * By Jimmy Wärting, https://github.com/jimmywarting


### PR DESCRIPTION
Sorry for such a big commit/change... would rather want to do smaller PR and many PR, but it often result in things taking longer for things to be accepted and merged...

----

When stream, arrayBuffer and text was announced i started to look back into node-fetch to try and implement dose functionalities... And they are there now.

But [node-fetch](https://github.com/bitinn/node-fetch) is looking into extracting out there own [Blob](https://github.com/bitinn/node-fetch/blob/master/src/blob.js) implementation and use a third-party blob implementation instead, figured instead of creating yet another module we could use something that already exist. so i looked back into your Blob.js implementation.

If node-fetch is ever going to use your version of blob.js then there are a few things that needs to happen before we even consider it. And that is what this PR is solving.

- stream, text and arrayBuffer need to exist.
- Node is going to want to have typed arrays (this pr now use them when possible)
- text must provide the same result as `response.text()` and `FileReader.readAsText`
  - (your current version didn't) test the [old](https://jsfiddle.net/yma9r6bf/) and the [new (this PR)](https://jsfiddle.net/yma9r6bf/1/) in jsfiddle
- setting Symbol.toStringTag didn't work correctly when blob was undefined
- other nice things that i found while search browsers native test harness
  - 6682a51 (discard bad mimetype)
  - 5735017 (change `/` to `:` in FileNames) 


closes #65
closes #66